### PR TITLE
Refactored messages Array on client to use a Map

### DIFF
--- a/client/app/components/chat/MessageChannel.tsx
+++ b/client/app/components/chat/MessageChannel.tsx
@@ -5,14 +5,16 @@ import Message from "./ChatMessage";
 import { MessageChannelProps } from "../../types/Props";
 import { TouchableOpacity } from "react-native";
 import SheetModal from "./SheetModal";
+import { UserProfile } from "../../types/User";
 
 const MessageChannel: React.FC<MessageChannelProps> = ({
   nearbyUsers,
   messages,
 }) => {
   const [isModalVisible, setModalVisible] = useState(false);
-  const reverseMessages = [...messages].reverse();
 
+  const messagesArray = Array.from(messages.values())
+                             .sort((a, b) => b.timestamp - a.timestamp);
 
   const handleLongPress = () => {
     setModalVisible(true);
@@ -28,11 +30,17 @@ const MessageChannel: React.FC<MessageChannelProps> = ({
       contentContainerStyle={{
         width: "100%",
       }}
-      data={reverseMessages}
+      data={messagesArray}
       renderItem={({ item }) => {
-        const user = nearbyUsers[item.author];
-        // console.log(nearbyUsers);
-        if (user === undefined) return null;
+        const user: UserProfile = nearbyUsers[item.author];
+        // Mock data for testing when socket server isn't working
+        // const user: UserProfile = { displayName: "You", profilePicture: 1 };
+        if (user === undefined) {
+          console.log(
+            `Message recieved from user not in nearbyUsers (${item.author})`
+          );
+          return null;
+        }
         return (
           <TouchableOpacity onLongPress={ handleLongPress }>
           <Message

--- a/client/app/screens/chat/ChatScreen.tsx
+++ b/client/app/screens/chat/ChatScreen.tsx
@@ -3,7 +3,6 @@ import {
   KeyboardAvoidingView,
   Platform,
   View,
-  Text,
   StyleSheet,
   Dimensions,
 } from "react-native";

--- a/client/app/screens/chat/ChatScreen.tsx
+++ b/client/app/screens/chat/ChatScreen.tsx
@@ -35,7 +35,7 @@ const ChatScreen = () => {
   // Note: To prevent complexity, all user information is grabbed from different contexts and services. If we wanted most information inside of UserContext, we would have to import contexts within contexts and have state change as certain things mount, which could cause errors that are difficult to pinpoint.
 
   // Message loading and sending logic
-  const [messages, setMessages] = useState<Message[]>([]);
+  const [messages, setMessages] = useState<Map<string, Message>>(new Map());
   const [messageContent, setMessageContent] = useState<string>("");
 
   useEffect(() => {
@@ -50,7 +50,11 @@ const ChatScreen = () => {
         );
         await refreshNearbyUsers(socket);
       }
-      setMessages((prevMessages) => [...prevMessages, message]);
+      setMessages((prevMessages) => {
+        const newMessages = new Map(prevMessages);
+        newMessages.set(message.id, message);
+        return newMessages;
+      });
       if (ack) console.log("Server acknowledged message:", ack);
     };
 
@@ -67,9 +71,9 @@ const ChatScreen = () => {
     if (socket === null) return;
 
     const newMessage: Message = {
+      id: Crypto.randomUUID(),
       author: String(userAuth.userAuthInfo?.uid),
-      //msgId: Crypto.randomUUID(),
-      timestamp: -1, // timestamp will be overridden by socket server
+      timestamp: Date.now(), // timestamp will be overridden by server
       content: { text: messageContent.trim() },
       location: {
         lat: Number(location?.lat),
@@ -78,9 +82,17 @@ const ChatScreen = () => {
       replyTo: undefined,
       reactions: {},
     };
+    console.log(`[LOG] New message: ${newMessage.author
+      } - ${newMessage.content.text} (${newMessage.id})`);
     sendMessage(socket, newMessage);
 
     setMessageContent("");
+    // Optimistic UI update for testing when socket server isn't working
+    // setMessages((prevMessages) => {
+    //   const newMessages = new Map(prevMessages);
+    //   newMessages.set(newMessage.id, newMessage);
+    //   return newMessages;
+    // });
   };
 
   return (

--- a/client/app/services/SocketService.ts
+++ b/client/app/services/SocketService.ts
@@ -76,6 +76,13 @@ export const sendMessage = (
   socket: Socket,
   message: Message,
 ) => {
+  if (!socket.connected) {
+    console.error(
+      `Cannot send message "${message.content.text}" (socket not connected)`
+    );
+    return;
+  }
+  console.log(`Sending message "${message.content.text}" on socket ${socket.id} (${socket.active})`);
   socket.emit("sendMessage", message,
     (ack: string) => {
       console.log("sendMessage ack:", ack);

--- a/client/app/types/Message.ts
+++ b/client/app/types/Message.ts
@@ -1,6 +1,7 @@
 import { LocationType } from "./Location";
 
 export interface Message {
+  id: string,
   author: string,
   timestamp: number,
   content: {

--- a/client/app/types/Props.ts
+++ b/client/app/types/Props.ts
@@ -28,7 +28,7 @@ export type MessageProps = {
 
 export type MessageChannelProps = {
   nearbyUsers: { [uid: string]: UserProfile };
-  messages: Message[];
+  messages: Map<string, Message>;
 };
 
 export type SafeAreaWrapperProps = {

--- a/server/src/socket_server/methods/send_message.ts
+++ b/server/src/socket_server/methods/send_message.ts
@@ -36,7 +36,7 @@ export const sendMessage = (
     seen.add(recipient.uid);
 
     recipient.socket.emit("message", message);
-    console.log("[WS] Sent message to user <" + recipient.uid + ">");
+    console.log(`[WS] Sent message to user <${recipient.uid}>`);
   }
 
   if (ack) ack("success");

--- a/server/src/types/message.ts
+++ b/server/src/types/message.ts
@@ -1,15 +1,16 @@
 import { Location } from "../types"
 
 export interface Message {
-    author: string,
-    timestamp: number,
-    content: {
-        text?: string,
-        attachment?: string,
-    },
-    location: Location,
-    replyTo?: string,
-    reactions: {
-        [key: string]: number,
-    }
+  id: string,
+  author: string,
+  timestamp: number,
+  content: {
+    text?: string,
+    attachment?: string,
+  },
+  location: Location,
+  replyTo?: string,
+  reactions: {
+    [key: string]: number,
+  }
 }


### PR DESCRIPTION
For issue #232 

This PR refactors the messages state on the client (in `<ChatScreen />`) from an array (`Message[]`) to a Map with message IDs as keys (`Map<string, Message>`). To do this, I also had to add a message ID attribute using a UUID generated with `expo-crypto`. The messages map is passed to `<MessageChannel />` as a map, which is then converted/sorted inside `<MessageChannel />` on render.

For future improvements, it may be a good idea to persist a sorted array on the client in addition to the map, so that it does not have to be created and sorted on every rerender. This is not a big problem for now but may introduce some performance costs when scaling to large and quickly updating chats. A hybrid approach may allow for the best of both data structures.

It should also be noted that the current broken state of socket server connection management made it difficult to test this refactor as it could not be run altogether. Instead, I injected some mock data (I left this commented out for others to use) at the broken points as a temporary solution. 